### PR TITLE
Restart preview generation if Krita was too busy to fetch the image

### DIFF
--- a/gmic-qt/src/GmicProcessor.cpp
+++ b/gmic-qt/src/GmicProcessor.cpp
@@ -192,6 +192,11 @@ bool GmicProcessor::isIdle() const
   return !_filterThread;
 }
 
+bool GmicProcessor::isInputImagesEmpty() const
+{
+  return _gmicImages->is_empty();
+}
+
 int GmicProcessor::duration() const
 {
   if (_filterThread) {

--- a/gmic-qt/src/GmicProcessor.h
+++ b/gmic-qt/src/GmicProcessor.h
@@ -92,6 +92,7 @@ public:
 
   bool isProcessing() const;
   bool isIdle() const;
+  bool isInputImagesEmpty() const;
   bool hasUnfinishedAbortedThreads() const;
 
   const cimg_library::CImg<float> & previewImage() const;

--- a/gmic-qt/src/MainWindow.cpp
+++ b/gmic-qt/src/MainWindow.cpp
@@ -760,6 +760,14 @@ void MainWindow::onPreviewImageAvailable()
 
 void MainWindow::onPreviewError(const QString & message)
 {
+  // if Kirta is too busy generating the images, restart the
+  // the preview process
+  if (_processor.isInputImagesEmpty()) {
+      CroppedImageListProxy::clear();
+      QTimer::singleShot(1000, ui->previewWidget, SLOT(sendUpdateRequest()));
+      return;
+  }
+
   ui->previewWidget->setPreviewErrorMessage(message);
   ui->previewWidget->enableRightClick();
 #ifndef _GMIC_QT_DISABLE_UPDATES_


### PR DESCRIPTION
A bugfix for https://bugs.kde.org/show_bug.cgi?id=455891